### PR TITLE
adds Snyk to "Open Source Threat Intelligence" -> "Tools"

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ A curated list of awesome malware analysis tools and resources. Inspired by
 * [PassiveTotal](https://www.passivetotal.org/) - Research, connect, tag and
   share IPs and domains.
 * [PyIOCe](https://github.com/pidydx/PyIOCe) - A Python OpenIOC editor.
+* [Snyk](https://snyk.io/) - NodeJS CLI and build-time tool to find & fix known vulnerabilities in npm dependencies.
 * [threataggregator](https://github.com/jpsenior/threataggregator) -
   Aggregates security threats from a number of sources, including some of
   those listed below in [other resources](#other-resources).


### PR DESCRIPTION
https://snyk.io/
https://github.com/Snyk/snyk
